### PR TITLE
setup: explicit installation of language-specific JSON files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,5 +25,10 @@ setup(
         'Intended Audience :: Developers',
         'Topic :: Internet',
     ],
+    package_data={
+        'yr': [
+            'languages/*.json',
+        ],
+    },
     install_requires = ['xmltodict'], # $$solve$$ ~> /usr/lib/python3.4/distutils/dist.py:260: UserWarning: Unknown distribution option: 'install_requires' warnings.warn(msg)
 )


### PR DESCRIPTION
Add language specific JSON files to installation script.
There's a FileNotFoundError if these are missing from the package installation directory.
(Tested on Debian 8, amd64)